### PR TITLE
Revamp admin panel with WhatsApp-inspired theme

### DIFF
--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WhatsApp Bot Admin</title>
+    <title>WappFlow Admin</title>
   </head>
-  <body class="bg-gray-900 text-gray-100">
+  <body class="bg-wa-bg text-gray-100">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/admin/src/App.tsx
+++ b/src/admin/src/App.tsx
@@ -1,35 +1,56 @@
 import React from "react";
-import { NavLink, Routes, Route, useNavigate } from "react-router-dom";
+import { NavLink, Routes, Route } from "react-router-dom";
+import {
+  HomeIcon,
+  PaperAirplaneIcon,
+  ClockIcon,
+  BellIcon,
+  QrCodeIcon,
+} from "./lib/icons";
 import Dashboard from "./pages/Dashboard";
 import Send from "./pages/Send";
 import Scheduling from "./pages/Scheduling";
 import Alerts from "./pages/Alerts";
 import Qr from "./pages/Qr";
 
+const navItems = [
+  { to: "/", label: "Dashboard", icon: HomeIcon },
+  { to: "/send", label: "Send", icon: PaperAirplaneIcon },
+  { to: "/scheduling", label: "Scheduling", icon: ClockIcon },
+  { to: "/alerts", label: "Alerts", icon: BellIcon },
+  { to: "/qr", label: "QR", icon: QrCodeIcon },
+];
+
 const navClasses = ({ isActive }: { isActive: boolean }) =>
-  `px-3 py-2 rounded-md text-sm font-medium ${isActive ? "bg-gray-700 text-white" : "text-gray-300 hover:bg-gray-700 hover:text-white"}`;
+  `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+    isActive
+      ? "bg-wa-green text-wa-bg"
+      : "text-gray-300 hover:bg-wa-hover hover:text-white"
+  }`;
 
 export default function App() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <nav className="bg-gray-800 px-4 py-3 flex gap-4">
-        <NavLink to="/" end className={navClasses}>
-          Dashboard
-        </NavLink>
-        <NavLink to="/send" className={navClasses}>
-          Send
-        </NavLink>
-        <NavLink to="/scheduling" className={navClasses}>
-          Scheduling
-        </NavLink>
-        <NavLink to="/alerts" className={navClasses}>
-          Alerts
-        </NavLink>
-        <NavLink to="/qr" className={navClasses}>
-          QR
-        </NavLink>
+    <div className="min-h-screen flex bg-wa-bg text-gray-100">
+      <nav className="w-56 bg-wa-panel p-4 space-y-2">
+        <div className="text-2xl font-semibold text-wa-green mb-6">
+          WappFlow
+        </div>
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === "/"}
+              className={navClasses}
+            >
+              <Icon className="h-5 w-5" />
+              <span>{item.label}</span>
+            </NavLink>
+          );
+        })}
       </nav>
-      <main className="flex-1 p-4 overflow-auto">
+      <main className="flex-1 p-6 overflow-auto">
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/send" element={<Send />} />

--- a/src/admin/src/lib/icons.tsx
+++ b/src/admin/src/lib/icons.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+export function HomeIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 10.5L12 4l9 6.5V20a1 1 0 01-1 1h-6v-6H10v6H4a1 1 0 01-1-1v-9.5z"
+      />
+    </svg>
+  );
+}
+
+export function PaperAirplaneIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.5 4.5l17 7.5-17 7.5 4-7.5-4-7.5z"
+      />
+    </svg>
+  );
+}
+
+export function ClockIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 7v5l3 3" />
+    </svg>
+  );
+}
+
+export function BellIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 17H9a4 4 0 01-4-4v-2a6 6 0 0112 0v2a4 4 0 01-4 4z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.73 21a2 2 0 01-3.46 0"
+      />
+    </svg>
+  );
+}
+
+export function QrCodeIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 3h6v6H3zM15 3h6v6h-6zM3 15h6v6H3zM13 13h2v2h-2zM17 13h4v4h-4zM13 17h2v4h-2z"
+      />
+    </svg>
+  );
+}

--- a/src/admin/src/pages/Alerts.tsx
+++ b/src/admin/src/pages/Alerts.tsx
@@ -42,7 +42,7 @@ export default function Alerts() {
       <h1 className="text-2xl font-bold">Alerts</h1>
       <ul className="space-y-2">
         {alerts.map((a) => (
-          <li key={a.ts} className="bg-gray-800 p-3 rounded-lg">
+          <li key={a.ts} className="bg-wa-panel p-3 rounded-lg">
             <div className="text-sm text-gray-400">
               {new Date(a.ts).toLocaleString()}
             </div>

--- a/src/admin/src/pages/Dashboard.tsx
+++ b/src/admin/src/pages/Dashboard.tsx
@@ -60,27 +60,27 @@ export default function Dashboard() {
       <h1 className="text-2xl font-bold">Dashboard</h1>
       {health && (
         <div className="grid grid-cols-2 gap-4">
-          <div className="bg-gray-800 p-4 rounded-lg">
+          <div className="bg-wa-panel p-4 rounded-lg">
             <div className="text-lg font-medium">Session</div>
             <p>{health.session.ready ? "Ready" : "Not ready"}</p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg">
+          <div className="bg-wa-panel p-4 rounded-lg">
             <div className="text-lg font-medium">Daily Usage</div>
             <p>
               {health.sentToday} / {health.dailyCap}
             </p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg">
+          <div className="bg-wa-panel p-4 rounded-lg">
             <div className="text-lg font-medium">Minute Tokens</div>
             <p>{health.perMinAvailable} available</p>
           </div>
-          <div className="bg-gray-800 p-4 rounded-lg">
+          <div className="bg-wa-panel p-4 rounded-lg">
             <div className="text-lg font-medium">Headless</div>
             <p>{health.headless ? "Enabled" : "Disabled"}</p>
           </div>
         </div>
       )}
-      <div className="bg-gray-800 p-4 rounded-lg space-y-4">
+      <div className="bg-wa-panel p-4 rounded-lg space-y-4">
         <h2 className="text-lg font-medium">Quick Send</h2>
         <form onSubmit={handleSend} className="space-y-2">
           <div>
@@ -89,7 +89,7 @@ export default function Dashboard() {
               placeholder="E.164 Phone"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div>
@@ -97,7 +97,7 @@ export default function Dashboard() {
               placeholder="Message"
               value={text}
               onChange={(e) => setText(e.target.value)}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div className="flex items-center space-x-2">
@@ -111,7 +111,7 @@ export default function Dashboard() {
           </div>
           <button
             type="submit"
-            className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded"
+            className="bg-wa-green hover:bg-wa-green/80 px-4 py-2 rounded text-wa-bg"
           >
             Send
           </button>
@@ -121,13 +121,13 @@ export default function Dashboard() {
       <div className="flex gap-4">
         <button
           onClick={handleSubscribe}
-          className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded"
+          className="bg-wa-green hover:bg-wa-green/80 px-4 py-2 rounded text-wa-bg"
         >
           Subscribe to Push
         </button>
         <button
           onClick={() => testPush()}
-          className="bg-purple-600 hover:bg-purple-700 px-4 py-2 rounded"
+          className="bg-wa-green hover:bg-wa-green/80 px-4 py-2 rounded text-wa-bg"
         >
           Test Push
         </button>

--- a/src/admin/src/pages/Qr.tsx
+++ b/src/admin/src/pages/Qr.tsx
@@ -14,7 +14,7 @@ export default function Qr() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">QR Code</h1>
-      <div className="bg-gray-800 p-4 rounded-lg inline-block">
+      <div className="bg-wa-panel p-4 rounded-lg inline-block">
         {src ? (
           <img src={src} alt="QR" className="max-w-full" />
         ) : (

--- a/src/admin/src/pages/Scheduling.tsx
+++ b/src/admin/src/pages/Scheduling.tsx
@@ -150,7 +150,7 @@ export default function Scheduling() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Scheduling</h1>
       {/* Create form */}
-      <div className="bg-gray-800 p-4 rounded-lg space-y-4 max-w-xl">
+      <div className="bg-wa-panel p-4 rounded-lg space-y-4 max-w-xl">
         <h2 className="text-lg font-medium">Create Schedule</h2>
         <form onSubmit={handleCreate} className="space-y-3">
           <div>
@@ -163,7 +163,7 @@ export default function Scheduling() {
                 setSelected(null);
                 if (e.target.value) setShowAll(false);
               }}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
             {suggestions.length > 0 ? (
               <div className="mt-2 max-h-48 overflow-y-auto space-y-2">
@@ -178,7 +178,7 @@ export default function Scheduling() {
                         phone: c.phone ? `${c.name} (${c.phone})` : c.name,
                       });
                     }}
-                    className="block w-full text-left bg-gray-700 hover:bg-gray-600 p-2 rounded"
+                    className="block w-full text-left bg-wa-hover hover:bg-wa-panel p-2 rounded"
                   >
                     <div className="font-medium">{c.name}</div>
                     {c.phone && (
@@ -200,7 +200,7 @@ export default function Scheduling() {
                 <button
                   type="button"
                   onClick={() => setShowAll(true)}
-                  className="text-blue-400 text-sm mt-2"
+                  className="text-wa-green text-sm mt-2"
                 >
                   View all
                 </button>
@@ -211,7 +211,7 @@ export default function Scheduling() {
             <textarea
               value={form.text}
               onChange={(e) => setForm({ ...form, text: e.target.value })}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div className="flex items-center space-x-2">
@@ -231,7 +231,7 @@ export default function Scheduling() {
               type="datetime-local"
               value={form.firstRunAt}
               onChange={(e) => setForm({ ...form, firstRunAt: e.target.value })}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div>
@@ -244,7 +244,7 @@ export default function Scheduling() {
               onChange={(e) =>
                 setForm({ ...form, intervalMinutes: e.target.value })
               }
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div className="flex items-center space-x-2">
@@ -258,7 +258,7 @@ export default function Scheduling() {
           </div>
           <button
             type="submit"
-            className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded"
+            className="bg-wa-green hover:bg-wa-green/80 px-4 py-2 rounded text-wa-bg"
           >
             Create
           </button>
@@ -266,11 +266,11 @@ export default function Scheduling() {
         </form>
       </div>
       {/* List */}
-      <div className="bg-gray-800 p-4 rounded-lg">
+      <div className="bg-wa-panel p-4 rounded-lg">
         <h2 className="text-lg font-medium mb-4">Existing Schedules</h2>
         <div className="overflow-x-auto">
           <table className="min-w-full text-left text-sm">
-            <thead className="bg-gray-700">
+            <thead className="bg-wa-hover">
               <tr>
                 <th className="px-3 py-2">Contact</th>
                 <th className="px-3 py-2">Message</th>
@@ -283,7 +283,7 @@ export default function Scheduling() {
             </thead>
             <tbody>
               {schedules.map((s) => (
-                <tr key={s.id} className="odd:bg-gray-700">
+                <tr key={s.id} className="odd:bg-wa-hover">
                   <td className="px-3 py-2 whitespace-nowrap">
                     {s.name || s.phone}
                   </td>
@@ -320,7 +320,7 @@ export default function Scheduling() {
                     </button>
                     <button
                       onClick={() => handleRun(s.id)}
-                      className="bg-green-600 hover:bg-green-700 px-2 py-1 rounded"
+                      className="bg-wa-green hover:bg-wa-green/80 px-2 py-1 rounded text-wa-bg"
                     >
                       Run
                     </button>
@@ -355,7 +355,7 @@ export default function Scheduling() {
       {/* Edit modal */}
       {edit && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-gray-800 p-6 rounded-lg space-y-4 w-96">
+          <div className="bg-wa-panel p-6 rounded-lg space-y-4 w-96">
             <h3 className="text-lg font-medium">Edit Schedule</h3>
             <form onSubmit={handleUpdate} className="space-y-3">
               <div>
@@ -363,7 +363,7 @@ export default function Scheduling() {
                 <textarea
                   value={edit.text}
                   onChange={(e) => setEdit({ ...edit, text: e.target.value })}
-                  className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+                  className="w-full px-3 py-2 rounded bg-wa-hover text-white"
                 />
               </div>
               <div className="flex items-center space-x-2">
@@ -385,7 +385,7 @@ export default function Scheduling() {
                   onChange={(e) =>
                     setEdit({ ...edit, firstRunAt: e.target.value })
                   }
-                  className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+                  className="w-full px-3 py-2 rounded bg-wa-hover text-white"
                 />
               </div>
               <div>
@@ -398,7 +398,7 @@ export default function Scheduling() {
                   onChange={(e) =>
                     setEdit({ ...edit, intervalMinutes: e.target.value })
                   }
-                  className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+                  className="w-full px-3 py-2 rounded bg-wa-hover text-white"
                 />
               </div>
               <div className="flex items-center space-x-2">
@@ -416,7 +416,7 @@ export default function Scheduling() {
                 <button
                   type="button"
                   onClick={() => setEdit(null)}
-                  className="bg-gray-600 hover:bg-gray-700 px-3 py-1 rounded"
+                  className="bg-wa-hover hover:bg-wa-panel px-3 py-1 rounded"
                 >
                   Cancel
                 </button>

--- a/src/admin/src/pages/Send.tsx
+++ b/src/admin/src/pages/Send.tsx
@@ -54,7 +54,7 @@ export default function Send() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Send Message</h1>
-      <div className="bg-gray-800 p-4 rounded-lg space-y-4 max-w-md">
+      <div className="bg-wa-panel p-4 rounded-lg space-y-4 max-w-md">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block mb-1">Contact</label>
@@ -66,7 +66,7 @@ export default function Send() {
                 setSelected(null);
                 if (e.target.value) setShowAll(false);
               }}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
             {suggestions.length > 0 ? (
               <div className="mt-2 max-h-48 overflow-y-auto space-y-2">
@@ -78,7 +78,7 @@ export default function Send() {
                       setSelected(c);
                       setPhone(c.phone ? `${c.name} (${c.phone})` : c.name);
                     }}
-                    className="block w-full text-left bg-gray-700 hover:bg-gray-600 p-2 rounded"
+                    className="block w-full text-left bg-wa-hover hover:bg-wa-panel p-2 rounded"
                   >
                     <div className="font-medium">{c.name}</div>
                     {c.phone && (
@@ -98,7 +98,7 @@ export default function Send() {
               <button
                 type="button"
                 onClick={() => setShowAll(true)}
-                className="text-blue-400 text-sm mt-2"
+                className="text-wa-green text-sm mt-2"
               >
                 View all
               </button>
@@ -109,7 +109,7 @@ export default function Send() {
             <textarea
               value={text}
               onChange={(e) => setText(e.target.value)}
-              className="w-full px-3 py-2 rounded bg-gray-700 text-white"
+              className="w-full px-3 py-2 rounded bg-wa-hover text-white"
             />
           </div>
           <div className="flex items-center space-x-2">
@@ -123,7 +123,7 @@ export default function Send() {
           </div>
           <button
             type="submit"
-            className="bg-green-600 hover:bg-green-700 px-4 py-2 rounded"
+            className="bg-wa-green hover:bg-wa-green/80 px-4 py-2 rounded text-wa-bg"
           >
             Send
           </button>

--- a/src/admin/tailwind.config.cjs
+++ b/src/admin/tailwind.config.cjs
@@ -3,7 +3,14 @@ module.exports = {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{ts,tsx,jsx,js}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "wa-bg": "#111b21",
+        "wa-panel": "#1f2c34",
+        "wa-hover": "#2a3942",
+        "wa-green": "#00a884",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- Introduce WhatsApp-like dark palette in Tailwind config and apply it across admin pages
- Replace top navigation with branded sidebar and custom SVG icons
- Restyle forms and cards on dashboard, send, scheduling, alerts and QR pages using new color scheme

## Testing
- `npm run build`
- `npm run admin:build`
- `npx prettier src/admin --check`


------
https://chatgpt.com/codex/tasks/task_e_68b4be8825b8832c99a95e2df16fd781